### PR TITLE
Fix ruby tag stripping regex

### DIFF
--- a/packages/aozorabunko/book-content-interface.ts
+++ b/packages/aozorabunko/book-content-interface.ts
@@ -19,8 +19,9 @@ export class SimpleBookContent implements BookContentInterface {
   }
 
   toStringWithoutTags(): string {
+    const captureBase = /<ruby>(?:<rb>)?([^<]*?)(?:<\/rb>)?(?:.|\n)*?<\/ruby>/g;
     const _contents = this.contents.map((content) =>
-      content.replace(/<ruby>.*?<rb>(.*?)<\/rb>.*?<\/ruby>/g, "$1").replace(/<[^>]*>/g, ""),
+      content.replace(captureBase, "$1").replace(/<[^>]*>/g, ""),
     );
     return _contents.join("\n\n");
   }

--- a/src/lib/regex.test.ts
+++ b/src/lib/regex.test.ts
@@ -28,6 +28,13 @@ describe("Boundary tests for regex.html.ruby.captureBase", () => {
     expect(matches[0][1]).toBe("あ");
   });
 
+  it("should match ruby tag without rb", () => {
+    const text = "<ruby>漢字<rt>かんじ</rt></ruby>";
+    const matches = [...text.matchAll(regex.html.ruby.captureBase)];
+    expect(matches.length).toBe(1);
+    expect(matches[0][1]).toBe("漢字");
+  });
+
   it("should match when rb tag is very long", () => {
     const longStr = "ギャル".repeat(1000);
     const text = `<ruby><rb>${longStr}</rb></ruby>`;

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,8 +1,9 @@
 export const regex = {
   html: {
     ruby: {
-      captureBase: /<ruby>.*?<rb>(.*?)<\/rb>.*?<\/ruby>/g,
-    },
+        captureBase:
+          /<ruby>(?:<rb>)?([^<]*?)(?:<\/rb>)?(?:.|\n)*?<\/ruby>/g,
+      },
     allTags: /<[^>]*>/g,
   },
   illustrationPlan: /<plan>[\s\S]*?<\/plan>/,


### PR DESCRIPTION
## Summary
- handle `<ruby>` tags that don't use `<rb>` when removing ruby markup
- update simple book content implementation accordingly
- cover regex with a test

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*