### PR TITLE
Use AOZORA_PATH env var for html paths

### DIFF
--- a/packages/aozorabunko-card-lists/get-aozora-bunko-html-url.test.ts
+++ b/packages/aozorabunko-card-lists/get-aozora-bunko-html-url.test.ts
@@ -61,11 +61,14 @@ describe("getAozoraBunkoHtmlUrl", () => {
 
 describe("convertHtmlUrlToFilePath", () => {
   it("URLからファイルパスに変換する", () => {
+    const originalEnv = process.env.AOZORA_PATH;
+    process.env.AOZORA_PATH = "/tmp/aozora";
     const url = "https://www.aozora.gr.jp/cards/001091/files/59835_72466.html";
     const expected =
-      "/Users/yoshikouki/src/github.com/aozorabunko/aozorabunko/cards/001091/files/59835_72466.html";
+      "/tmp/aozora/cards/001091/files/59835_72466.html";
 
     expect(convertHtmlUrlToFilePath(url)).toBe(expected);
+    process.env.AOZORA_PATH = originalEnv;
   });
 
   it("青空文庫以外のURLの場合はエラーをスローする", () => {

--- a/packages/aozorabunko-card-lists/get-aozora-bunko-html-url.ts
+++ b/packages/aozorabunko-card-lists/get-aozora-bunko-html-url.ts
@@ -57,7 +57,8 @@ export function convertHtmlUrlToFilePath(htmlFileUrl: string): string {
     throw new Error("Unexpected URL format");
   }
 
-  return (
-    "/Users/yoshikouki/src/github.com/aozorabunko/aozorabunko/" + pathParts.slice(1).join("/")
-  );
+  const basePath =
+    process.env.AOZORA_PATH ||
+    "/Users/yoshikouki/src/github.com/aozorabunko/aozorabunko";
+  return path.join(basePath, ...pathParts.slice(1));
 }


### PR DESCRIPTION
## Summary
- allow overriding aozora repo path with `AOZORA_PATH`
- test that `convertHtmlUrlToFilePath` uses env var

## Testing
- `bun run test` *(fails: `vitest: command not found`)*