### PR TITLE
Add complex ruby tag tests

### DIFF
--- a/packages/aozorabunko/src/transformer/ruby.test.ts
+++ b/packages/aozorabunko/src/transformer/ruby.test.ts
@@ -68,4 +68,72 @@ describe("transformRuby", () => {
       ],
     });
   });
+
+  it("transforms ruby with rb and rp elements", () => {
+    const ast = {
+      type: "element",
+      tagName: "ruby",
+      children: [
+        { type: "element", tagName: "rb", children: [{ type: "text", value: "漢" }] },
+        { type: "element", tagName: "rp", children: [{ type: "text", value: "（" }] },
+        { type: "element", tagName: "rt", children: [{ type: "text", value: "かん" }] },
+        { type: "element", tagName: "rp", children: [{ type: "text", value: "）" }] },
+      ],
+    };
+    const result = transformRuby(ast);
+    expect(result).toEqual({
+      type: "element",
+      tagName: "Ruby",
+      properties: { kana: "かん" },
+      children: [
+        { type: "element", tagName: "rb", children: [{ type: "text", value: "漢" }] },
+        { type: "element", tagName: "rp", children: [{ type: "text", value: "（" }] },
+        { type: "element", tagName: "rp", children: [{ type: "text", value: "）" }] },
+      ],
+    });
+  });
+
+  it("transforms multiple ruby tags within text", () => {
+    const ast = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "ruby",
+          children: [
+            { type: "text", value: "日本" },
+            { type: "element", tagName: "rt", children: [{ type: "text", value: "にほん" }] },
+          ],
+        },
+        { type: "text", value: "語" },
+        {
+          type: "element",
+          tagName: "ruby",
+          children: [
+            { type: "text", value: "F" },
+            { type: "element", tagName: "rt", children: [{ type: "text", value: "エフ" }] },
+          ],
+        },
+      ],
+    };
+    const result = transformRuby(ast);
+    expect(result).toEqual({
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "Ruby",
+          properties: { kana: "にほん" },
+          children: [{ type: "text", value: "日本" }],
+        },
+        { type: "text", value: "語" },
+        {
+          type: "element",
+          tagName: "Ruby",
+          properties: { kana: "エフ" },
+          children: [{ type: "text", value: "F" }],
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend `transformRuby` tests for rb/rp elements
- cover multiple ruby tags in text

## Testing
- `npx vitest run packages/aozorabunko/src/transformer/ruby.test.ts`
- `pnpm run test`
